### PR TITLE
Right way to declare dependencies

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -13,7 +13,7 @@
             "requires" : [
                 "DB",
                 "NativeLibs:ver<0.0.7>:auth<github:salortiz>",
-                "sqlite:from<native>"
+                "sqlite:from<native>:ver<0>"
             ]
         },
         "test" : {

--- a/META6.json
+++ b/META6.json
@@ -13,7 +13,7 @@
             "requires" : [
                 "DB",
                 "NativeLibs:ver<0.0.7>:auth<github:salortiz>",
-                "sqlite:from<native>:ver<0>"
+                "sqlite3:from<native>:ver<0>"
             ]
         },
         "test" : {


### PR DESCRIPTION
* Based on http://rakudist.raku.org/sparky/report/centos/422
* Some new distros ( for example recent CentOS ) do not have sqlite2 in repos, so I'd recommend to rely on sqlite3
